### PR TITLE
Add stereoscopic 3D to Top Screen Visuals

### DIFF
--- a/source/background.c
+++ b/source/background.c
@@ -56,16 +56,19 @@ void updateBubble(bubble_t* bubble)
 	}
 }
 
-void drawBubbles(void)
+void drawBubbles(gfx3dSide_t side)
 {
 	int i;
 	//BUBBLES!!
 	for(i = 0;i < BUBBLE_COUNT;i += 1)
 	{
+		if(bubbles[i].y < 240 && side == GFX_RIGHT)
+			continue; //Don't draw bottom bubbles twice
+
 		// Then draw (no point in separating more because then we go through them all twice).
-		gfxDrawSpriteAlphaBlendFade((bubbles[i].y >= 240) ? (GFX_TOP) : (GFX_BOTTOM), GFX_LEFT, (u8*)bubble_bin, 32, 32, 
+		gfxDrawSpriteAlphaBlendFade((bubbles[i].y >= 240) ? (GFX_TOP) : (GFX_BOTTOM), side, (u8*)bubble_bin, 32, 32, 
 			((bubbles[i].y >= 240) ? -64 : 0) + bubbles[i].y % 240, 
-			((bubbles[i].y >= 240) ? 0 : -40) + bubbles[i].x, bubbles[i].fade);
+			((bubbles[i].y >= 240) ? 0 : -40) + bubbles[i].x + (side == GFX_LEFT ? STEREO_SEPARATION / 2 : -STEREO_SEPARATION / 2), bubbles[i].fade);
 	}
 }
 
@@ -107,16 +110,28 @@ void drawBackground(u8 bgColor[3], u8 waterBorderColor[3], u8 waterColor[3])
 	//top screen stuff
 	//gfxFillColorGradient(GFX_TOP, GFX_LEFT, waterBorderColor, waterColor);
 	gfxFillColor(GFX_TOP, GFX_LEFT, bgColor);
-	gfxDrawWave(GFX_TOP, GFX_LEFT, waterBorderColor, waterColor, 135, 20, 5, (gfxWaveCallback)&evaluateWater, &waterEffect);
-	gfxDrawWave(GFX_TOP, GFX_LEFT, waterColor, waterBorderColor, 130, 20, 0, (gfxWaveCallback)&evaluateWater, &waterEffect);
+	gfxDrawWave(GFX_TOP, GFX_LEFT, waterBorderColor, waterColor, 135, 20, 5, STEREO_SEPARATION * 2, (gfxWaveCallback)&evaluateWater, &waterEffect);
+	gfxDrawWave(GFX_TOP, GFX_LEFT, waterColor, waterBorderColor, 130, 20, 0, STEREO_SEPARATION * 2, (gfxWaveCallback)&evaluateWater, &waterEffect);
 
 	//sub screen stuff
 	gfxFillColorGradient(GFX_BOTTOM, GFX_LEFT, waterColor, waterBorderColor);
 
 	// Bubbles belong on both screens so they should be drawn second to last.
-	drawBubbles();
+	drawBubbles(GFX_LEFT);
 
 	// Finally draw the logo.
 	gfxDrawSpriteAlphaBlend(GFX_TOP, GFX_LEFT, (u8*)logo_bin, 113, 271, 64, 80);
+
+	// If slider is on 3D, draw for right eye.
+	if(CONFIG_3D_SLIDERSTATE > 0)
+	{
+		gfxFillColor(GFX_TOP, GFX_RIGHT, bgColor);
+		gfxDrawWave(GFX_TOP, GFX_RIGHT, waterBorderColor, waterColor, 135, 20, 5, 0, (gfxWaveCallback)&evaluateWater, &waterEffect);
+		gfxDrawWave(GFX_TOP, GFX_RIGHT, waterColor, waterBorderColor, 130, 20, 0, 0, (gfxWaveCallback)&evaluateWater, &waterEffect);
+
+		drawBubbles(GFX_RIGHT);
+
+		gfxDrawSpriteAlphaBlend(GFX_TOP, GFX_RIGHT, (u8*)logo_bin, 113, 271, 64, 80);
+	}
 }
 

--- a/source/gfx.c
+++ b/source/gfx.c
@@ -285,7 +285,7 @@ void gfxFadeScreen(gfxScreen_t screen, gfx3dSide_t side, u32 f)
 	}
 }
 
-void gfxDrawWave(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 rgbColorEnd[3], u16 level, u16 amplitude, u16 width, gfxWaveCallback cb, void* p)
+void gfxDrawWave(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 rgbColorEnd[3], u16 level, u16 amplitude, u16 width, int shift, gfxWaveCallback cb, void* p)
 {
 	u16 fbWidth, fbHeight;
 	u8* fbAdr=gfxGetFramebuffer(screen, side, &fbWidth, &fbHeight);
@@ -304,7 +304,7 @@ void gfxDrawWave(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 r
 		}
 		for(j=0; j<fbHeight; j++)
 		{
-			u16 waveLevel=level+cb(p, j)*amplitude;
+			u16 waveLevel=level+cb(p, j+shift)*amplitude;
 			memcpy(&fbAdr[(waveLevel-width)*3], colorLine, width*3);
 			fbAdr+=fbWidth*3;
 		}
@@ -324,7 +324,7 @@ void gfxDrawWave(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 r
 
 		for(j=0; j<fbHeight; j++)
 		{
-			u16 waveLevel=level+cb(p, j)*amplitude;
+			u16 waveLevel=level+cb(p, j+shift)*amplitude;
 			memcpy(fbAdr, colorLine, waveLevel*3);
 			fbAdr+=fbWidth*3;
 		}

--- a/source/gfx.h
+++ b/source/gfx.h
@@ -2,6 +2,10 @@
 #include <3ds.h>
 #include "font.h"
 
+#define CONFIG_3D_SLIDERSTATE (*(float*)0x1FF81080) //TODO: Move to ctrulib!
+#define TOTAL_STEREO_SEPARATION 5 //Total separation at farthest depth (per eye)
+#define STEREO_SEPARATION (TOTAL_STEREO_SEPARATION * CONFIG_3D_SLIDERSTATE)
+
 typedef float (*gfxWaveCallback)(void* p, u16 x);
 
 //rendering stuff
@@ -16,4 +20,4 @@ void gfxDrawTextN(gfxScreen_t screen, gfx3dSide_t side, font_s* f, char* str, u1
 void gfxFillColor(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColor[3]);
 void gfxFillColorGradient(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 rgbColorEnd[3]);
 void gfxDrawRectangle(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColor[3], s16 x, s16 y, u16 width, u16 height);
-void gfxDrawWave(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 rgbColorEnd[3], u16 level, u16 amplitude, u16 width, gfxWaveCallback cb, void* p);
+void gfxDrawWave(gfxScreen_t screen, gfx3dSide_t side, u8 rgbColorStart[3], u8 rgbColorEnd[3], u16 level, u16 amplitude, u16 width, int shift, gfxWaveCallback cb, void* p);

--- a/source/main.c
+++ b/source/main.c
@@ -36,7 +36,10 @@ void renderFrame(u8 bgColor[3], u8 waterBorderColor[3], u8 waterColor[3])
 	drawBackground(bgColor, waterBorderColor, waterColor);
 
 	// status bar
-	drawStatusBar(wifiStatus, charging, batteryLevel);
+	drawStatusBar(wifiStatus, charging, batteryLevel, GFX_LEFT);
+
+	if(CONFIG_3D_SLIDERSTATE > 0)
+		drawStatusBar(wifiStatus, charging, batteryLevel, GFX_RIGHT);
 
 	// debug text
 	// drawDebug();
@@ -137,6 +140,7 @@ int main()
 	srvInit();
 	aptInit();
 	gfxInit();
+	gfxSet3D(true);
 	initFilesystem();
 	openSDArchive();
 	hidInit(NULL);

--- a/source/statusbar.c
+++ b/source/statusbar.c
@@ -26,7 +26,7 @@ u8* batteryLevels[] = {
 #define SECONDS_IN_HOUR 3600
 #define SECONDS_IN_MINUTE 60
 
-void drawStatusBar(bool wifiStatus, bool charging, int batteryLevel)
+void drawStatusBar(bool wifiStatus, bool charging, int batteryLevel, gfx3dSide_t side)
 {
 	u64 timeInSeconds = osGetTime() / 1000;
 	u64 dayTime = timeInSeconds % SECONDS_IN_DAY;
@@ -36,24 +36,24 @@ void drawStatusBar(bool wifiStatus, bool charging, int batteryLevel)
 
 	char timeString[9];
 	sprintf(timeString, "%02d:%02d:%02d", hour, min, seconds);
-	gfxDrawText(GFX_TOP, GFX_LEFT, NULL, timeString, 240 - 18, 400 / 2 - 16);
+	gfxDrawText(GFX_TOP, side, NULL, timeString, 240 - 18, 400 / 2 - 16);
 
 	if(wifiStatus)
 	{
-		gfxDrawSpriteAlphaBlend(GFX_TOP, GFX_LEFT, (u8*)wifi_full_bin, 18, 20, 240 - 18, 0);
+		gfxDrawSpriteAlphaBlend(GFX_TOP, side, (u8*)wifi_full_bin, 18, 20, 240 - 18, 0);
 	}
 	else
 	{
-		gfxDrawSpriteAlphaBlend(GFX_TOP, GFX_LEFT, (u8*)wifi_none_bin, 18, 20, 240 - 18, 0);
+		gfxDrawSpriteAlphaBlend(GFX_TOP, side, (u8*)wifi_none_bin, 18, 20, 240 - 18, 0);
 	}
 
 	if(charging)
 	{
-		gfxDrawSpriteAlphaBlend(GFX_TOP, GFX_LEFT, (u8*)battery_charging_bin, 18, 27, 240 - 18, 400 - 27);
+		gfxDrawSpriteAlphaBlend(GFX_TOP, side, (u8*)battery_charging_bin, 18, 27, 240 - 18, 400 - 27);
 	}
 	else
 	{
-		gfxDrawSpriteAlphaBlend(GFX_TOP, GFX_LEFT, batteryLevels[batteryLevel], 18, 27, 240 - 18, 400 - 27);
+		gfxDrawSpriteAlphaBlend(GFX_TOP, side, batteryLevels[batteryLevel], 18, 27, 240 - 18, 400 - 27);
 	}
 }
 

--- a/source/statusbar.h
+++ b/source/statusbar.h
@@ -1,4 +1,4 @@
 #pragma once
 #include <3ds.h>
 
-void drawStatusBar(bool wifiStatus, bool charging, int batteryLevel);
+void drawStatusBar(bool wifiStatus, bool charging, int batteryLevel, gfx3dSide_t side);


### PR DESCRIPTION
Currently sets the water background to a depth of 5 pixels per eye, with bubbles being half of that and all other UI elements sitting on the top without 3D separation. Only negative side-effects include framerate halfing due to render lag (because software rendering). It should also be noted that this pulls the 3D slider float value on it's own from 0x1FF81080 rather than ctrulib due to the absence of this value there (as far as I have found).

Since this PR is purely aesthetic the cons may outweigh the pros for this, but I figured I'd throw it up and see what anyone thinks. If you want to give it a whirl you can either compile it or use the binary [here](https://www.dropbox.com/s/mmyua1xr8h6plmi/boot.3dsx?dl=0). It may be better to wait for hardware rendering because at that point we can render all the elements once in a 3D scene and then from there just render twice in hardware for each eye. 