### PR TITLE
Added a 5s interval to SD checks, fixes #4, mostly.

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -14,6 +14,7 @@
 
 bool brewMode = false;
 u32 sdmcCurrent = 0;
+u64 nextSdCheck = 0;
 
 menu_s menu;
 u32 wifiStatus = 0;
@@ -157,6 +158,7 @@ int main()
 		scanHomebrewDirectory(&menu, "/3ds/");
 	}
 	sdmcPrevious = sdmcCurrent;
+	nextSdCheck = osGetTime()+5000;
 
 	srand(svcGetSystemTick());
 
@@ -164,19 +166,22 @@ int main()
 
 	while(aptMainLoop())
 	{
-		FSUSER_IsSdmcDetected(NULL, &sdmcCurrent);
+		if (nextSdCheck < osGetTime()) {
+			FSUSER_IsSdmcDetected(NULL, &sdmcCurrent);
 
-		if(sdmcCurrent == 1 && (sdmcPrevious == 0 || sdmcPrevious < 0))
-		{
-			closeSDArchive();
-			openSDArchive();
-			scanHomebrewDirectory(&menu, "/3ds/");
+			if(sdmcCurrent == 1 && (sdmcPrevious == 0 || sdmcPrevious < 0))
+			{
+				closeSDArchive();
+				openSDArchive();
+				scanHomebrewDirectory(&menu, "/3ds/");
+			}
+			else if(sdmcCurrent < 1 && sdmcPrevious == 1)
+			{
+				clearMenuEntries(&menu);
+			}
+			sdmcPrevious = sdmcCurrent;
+			nextSdCheck = osGetTime()+5000;
 		}
-		else if(sdmcCurrent < 1 && sdmcPrevious == 1)
-		{
-			clearMenuEntries(&menu);
-		}
-		sdmcPrevious = sdmcCurrent;
 
 		ACU_GetWifiStatus(NULL, &wifiStatus);
 		PTMU_GetBatteryLevel(NULL, &batteryLevel);


### PR DESCRIPTION
I think this is much more sane than polling the SD slot every frame anyways. This makes removing / adding my SD card in the HB menu comfortable, I haven't experienced any issues.
