### PR TITLE
Added a 250ms interval to SD checks, fixes #4, mostly.

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -158,7 +158,7 @@ int main()
 		scanHomebrewDirectory(&menu, "/3ds/");
 	}
 	sdmcPrevious = sdmcCurrent;
-	nextSdCheck = osGetTime()+5000;
+	nextSdCheck = osGetTime()+250;
 
 	srand(svcGetSystemTick());
 
@@ -166,7 +166,8 @@ int main()
 
 	while(aptMainLoop())
 	{
-		if (nextSdCheck < osGetTime()) {
+		if (nextSdCheck < osGetTime())
+		{
 			FSUSER_IsSdmcDetected(NULL, &sdmcCurrent);
 
 			if(sdmcCurrent == 1 && (sdmcPrevious == 0 || sdmcPrevious < 0))
@@ -180,7 +181,7 @@ int main()
 				clearMenuEntries(&menu);
 			}
 			sdmcPrevious = sdmcCurrent;
-			nextSdCheck = osGetTime()+5000;
+			nextSdCheck = osGetTime()+250;
 		}
 
 		ACU_GetWifiStatus(NULL, &wifiStatus);


### PR DESCRIPTION
I think this is much more sane than polling the SD slot every frame anyways. This makes removing / adding my SD card in the HB menu comfortable, I haven't experienced any issues.

The only "issue" I've experienced so far is that it stopped polling the SD card and simply displayed all the homebrew. It was fixed by opening an app and closing it. Non critical and definitely in a better state than it is on the master branch rn.
