### PR TITLE
Fixed an issue where the SD slot is no longer checked correctly

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -220,10 +220,6 @@ int main()
 			{
 				netloader_activate();
 				netloader_active = true;
-			}else if(hidKeysDown()&KEY_R)
-			{
-				fsExit();
-			    fsInit();
 			}
 			if(secretCode())brewMode = true;
 			else if(updateMenu(&menu))break;


### PR DESCRIPTION
It was simply an issue where sdmcCurrent was being checked as a u32 when it should be u8. This will probably be fixed in a future ctrulib version, for now this fix is fast and simple.
