### PR TITLE
Update for latest ctrulib

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -146,7 +146,7 @@ int main()
 {
 	srvInit();
 	aptInit();
-	gfxInit();
+	gfxInitDefault();
 	initFilesystem();
 	openSDArchive();
 	hidInit(NULL);


### PR DESCRIPTION
- Fix build error regarding gfxInit() when compiling against latest
ctrulib-git