### PR TITLE
Don't reboot in to gamecard on APT return-to-home

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -417,7 +417,7 @@ int main()
 	aptExit();
 	srvExit();
 
-	if(!strcmp(me->executablePath, REGIONFREE_PATH) && regionFreeAvailable && !netloader_boot)return regionFreeRun();
+	if(!strcmp(me->executablePath, REGIONFREE_PATH) && regionFreeAvailable && aptGetStatus() != APP_EXITING && !netloader_boot)return regionFreeRun();
 	
 	regionFreeExit();
 


### PR DESCRIPTION
Not sure if this affects ninjhax directly but with a 3DSX loader installed as a title, if you close the application via Home Menu return-to-home when the region free menu entry is selected, hbmenu currently triggers a reboot in to the gamecard.

Feel free to not accept this due to its irrelevance to ninjhax, but I thought I would put it up here anyways since someone else could probably run in to it.