### PR TITLE
Add the support of XML file when using Netloader

### DIFF
--- a/source/filesystem.c
+++ b/source/filesystem.c
@@ -196,6 +196,17 @@ void addExecutableToMenu(menu_s* m, char* execPath)
 	addMenuEntryCopy(m, &tmpEntry);
 }
 
+void loadDescriptorNetloaderApp(descriptor_s* d, char* execPath) {
+	static char xmlPath[128];
+	snprintf(xmlPath, 128, "%s", execPath);
+	int l = strlen(xmlPath);
+	xmlPath[l-1] = 0;
+	xmlPath[l-2] = 'l';
+	xmlPath[l-3] = 'm';
+	xmlPath[l-4] = 'x';
+	if(fileExists(xmlPath, &sdmcArchive)) loadDescriptor(d, xmlPath);
+}
+
 void addDirectoryToMenu(menu_s* m, char* path)
 {
 	if(!m || !path)return;

--- a/source/filesystem.h
+++ b/source/filesystem.h
@@ -24,3 +24,4 @@ void printDirectory(void);
 
 //shortcut menu stuff
 void createMenuEntryShortcut(menu_s* m, shortcut_s* s);
+void loadDescriptorNetloaderApp(descriptor_s* d, char* path);

--- a/source/menu.h
+++ b/source/menu.h
@@ -81,3 +81,4 @@ void initMenuEntry(menuEntry_s* me, char* execPath, char* name, char* descriptio
 int drawMenuEntry(menuEntry_s* me, gfxScreen_t screen, u16 x, u16 y, bool selected);
 
 void scanMenuEntry(menuEntry_s* me);
+void freeMenuEntry(menuEntry_s* me);


### PR DESCRIPTION
Here is the code changes to support the XML file when using Netloader.
If a XML file exist, the Title Selector shows up.

Very useful when debugging a Homebrew App which need the title selector to work properly, instead of adding the file manually or restarting the app.

Feel free to suggest code changes, I am not a good C programmer ;) 